### PR TITLE
Bugfix: "cp: cannot stat"

### DIFF
--- a/scripts/pre-reqs-linux.sh
+++ b/scripts/pre-reqs-linux.sh
@@ -172,4 +172,4 @@ for item in "${stuff[@]}"; do
   esac
 done
 
-cp "${BUILD_BIN}/*" /bin || e "Unable to install binaries"
+cp "${BUILD_BIN}"/* /bin || e "Unable to install binaries"

--- a/scripts/pre-reqs-linux.sh
+++ b/scripts/pre-reqs-linux.sh
@@ -173,3 +173,5 @@ for item in "${stuff[@]}"; do
 done
 
 cp "${BUILD_BIN}"/* /bin || e "Unable to install binaries"
+
+monolog INFO "Finished installing linux pre-reqs"

--- a/scripts/pre-reqs-macos.sh
+++ b/scripts/pre-reqs-macos.sh
@@ -49,3 +49,5 @@ for i in "${stuff[@]}"; do
     esac
   fi
 done
+
+monolog INFO "Finished installing macos pre-reqs"


### PR DESCRIPTION
This small fix is to address an issue executing `./pre-reqs` in the scripts directory.  Currently, the `cp` invocation is failing, since the asterisk is misplaced (IIUC), producing the following error:

```
cp: cannot stat '/home/ubuntu/opentdf/scripts/build-temp/bin/*': No such file or directory
 [ERROR]  [2022-06-30 15:43:50] "Unable to install binaries" 
```