### PR TITLE
bugfix: PLAT-1961: Configure Keycloak to use Postgres provided by OpenTDF

### DIFF
--- a/quickstart/helm/values-keycloak.yaml
+++ b/quickstart/helm/values-keycloak.yaml
@@ -2,30 +2,28 @@ image:
   # Keycloak is a non-OpenTDF chart, but with an OpenTDF image
   repository: ghcr.io/opentdf/keycloak
 postgresql:
+  # This next option (enabled) determines whehter or not Keycloak should 
+  # create a Postgres (uniquely) for Keycloak (true) or not (false).
+  # 
+  # Since it's set to fallse, we'll use the Postgres provided by OpenTDF
   enabled: false
-  postgresqlUsername: postgres
-  postgresqlPassword: mydbapassword
-  postgresqlDatabase: keycloak_database
-externalDatabase:
-  host: opentdf-postgresql
-  user: postgres
-  password: mydbapassword
-  database: keycloak_database
 extraEnv: |
   - name: CLAIMS_URL
     value: http://opentdf-entitlement-pdp:3355/entitlements
   - name: JAVA_OPTS_APPEND
     value: -Dkeycloak.profile=preview -Dkeycloak.profile.feature.token_exchange=enabled
-# - name: DB_VENDOR
-#   value: h2
-# - name: DB_VENDOR
-#   value: postgres
-# - name: DB_ADDR
-#   value: postgresql
-# - name: DB_DATABASE
-#   value: keycloak_database
-# - name: DB_PORT
-#   value: "5432"
+  - name: DB_ADDR
+    value: postgresql
+  - name: DB_DATABASE
+    value: keycloak_database
+  - name: DB_PORT
+    value: "5432"
+  - name: DB_VENDOR
+    value: postgres
+  - name: DB_USER
+    value: postgres
+  - name: DB_PASSWORD
+    value: myPostgresPassword
 # - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
 #   value: "true"
 # - name: KEYCLOAK_FRONTEND_URL

--- a/quickstart/helm/values-postgresql.yaml
+++ b/quickstart/helm/values-postgresql.yaml
@@ -1,8 +1,16 @@
 #  configuration https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#parameters
 image:
   debug: true
+# The auth block here configures Postgres to use a fixed value
+# rather than an auto-generated one.  More information
+# is available: https://github.com/bitnami/containers/tree/main/bitnami/postgresql 
+auth:
+  postgresPassword: myPostgresPassword
 initdbUser: postgres
-initdbPassword: mydbapassword
+initdbPassword: myPostgresPassword
+extraEnv: |
+  - name: POSTGRESQL_PASSWORD
+    value: myPostgresPassword
 initdbScripts:
   init.sql: |
     -- Keycloak DB


### PR DESCRIPTION
### Description
This change allows Keycloak to store data in the Postgres service provided by OpenTDF.

### Testing the change
You can test this change by performing the following steps: 

1. Launch a cluster
2. Add a new realm
3. Query the database and/or List the realms in the Keycloak UI
4. Delete the Keycloak pod (`kubectl delete pod/keycloak-0`).  Since it's data is persisted in Postgres, it will come back up with the existing state (e.g. your new realm is present) 
5. Query the database and/or List the realms in the Keycloak UI

### Without this PR
Performing the test procedure above, without this PR, will result in a Keycloak instance with no data stored.  In other words, when you delete the Keycloak pod it will lose it's in-memory database.

### Caveat
One note: An odd (but expected) item you'll see in the logs is that both H2 and Postgres drivers are loaded: 
```
$ kubectl logs keycloak-0 |grep -C 2 -F "Started Driver service"
16:32:41,795 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 56) WFLYUT0014: Creating file handler for path '/opt/jboss/keycloak/welcome-content' with options [directory-listing: 'false', follow-symlink: 'false', case-sensitive: 'true', safe-symlink-paths: '[]']
16:32:41,816 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-1) WFLYUT0003: Undertow 2.2.5.Final starting
16:32:41,991 INFO  [org.jboss.as.connector.deployers.jdbc] (MSC service thread 1-1) WFLYJCA0018: Started Driver service with driver-name = h2
16:32:42,038 INFO  [org.jboss.as.connector.deployers.jdbc] (MSC service thread 1-1) WFLYJCA0018: Started Driver service with driver-name = postgresql
16:32:42,104 INFO  [org.jboss.as.naming] (MSC service thread 1-1) WFLYNAM0003: Starting Naming Service
16:32:42,144 INFO  [org.jboss.as.ejb3] (MSC service thread 1-1) WFLYEJB0481: Strict pool slsb-strict-max-pool is using a max instance size of 16 (per class), which is derived from thread worker pool sizing.
```