### PR TITLE
make quickstart work

### DIFF
--- a/quickstart/helm/values-keycloak-bootstrap.yaml
+++ b/quickstart/helm/values-keycloak-bootstrap.yaml
@@ -5,7 +5,7 @@ image:
 externalUrl: http://offline.demo.internal/
 
 keycloak:
-  hostname: http://keycloak-http
+  hostname: http://keycloak-http/auth
   username: keycloakadmin
   password: mykeycloakpassword
   clientId: tdf-client


### PR DESCRIPTION
with recent backend changes bootstrap now pulls this hostname instead of internaloidc