### PR TITLE
🔨 Lets offline image pins match charts

### DIFF
--- a/examples/offline/build-offline-bundle
+++ b/examples/offline/build-offline-bundle
@@ -176,16 +176,16 @@ if [[ ! $no_third_party && ! $no_images ]]; then
 
   # postgresql
   # Update URI: https://hub.docker.com/r/bitnami/postgresql/tags
-  save-image bitnami/postgresql 12.8.0 third-party-image-postgresql
+  save-image bitnami/postgresql 11.14.0-debian-10-r28 third-party-image-postgresql
 
-  # Keycloak: We are using a custom image
+  # Keycloak: We are using a custom image with entitlement support
   save-image "ghcr.io/opentdf/keycloak" 18.0.2 "opentdf-keycloak"
 
   # nginx ingress
   save-image k8s.gcr.io/ingress-nginx/controller v1.1.1 third-party-image-ingress-nginx
 
   # docker registry
-  save-image registry 2.8.1 third-party-image-docker-registry
+  save-image registry 2.7.1 third-party-image-docker-registry
 fi
 
 if [[ ! $no_third_party && ! $no_charts ]]; then

--- a/quickstart/start.sh
+++ b/quickstart/start.sh
@@ -13,7 +13,7 @@ export PATH="$TOOLS_ROOT:$PATH"
 
 e() {
   local rval=$?
-  if [[ $rval ]]; then
+  if [[ $rval != 0 ]]; then
     monolog ERROR "${@}"
     exit $rval
   fi
@@ -194,12 +194,27 @@ if [[ $LOAD_SECRETS ]]; then
       keycloak)
         monolog TRACE "Creating 'keycloak-secrets'..."
         kubectl create secret generic keycloak-secrets \
-          --from-literal=DB_USER=postgres \
-          --from-literal=DB_PASSWORD=myPostgresPassword \
-          --from-literal=KEYCLOAK_USER=keycloakadmin \
-          --from-literal=KEYCLOAK_PASSWORD=mykeycloakpassword
+          --from-literal=KEYCLOAK_ADMIN=keycloakadmin \
+          --from-literal=KEYCLOAK_ADMIN_PASSWORD=mykeycloakpassword \
+          --from-literal=KC_HOSTNAME=localhost:65432 \
+          --from-literal=KC_HOSTNAME_ADMIN=localhost:65432 \
+          --from-literal=KC_DB_USERNAME=postgres \
+          --from-literal=KC_DB_PASSWORD=myPostgresPassword \
+          --from-literal=KC_DB_URL_HOST=postgresql \
+          --from-literal=KC_DB_URL_DATABASE=keycloak_database
+        e "create keycloak-secrets failed"
         ;;
-      abacus | entity-resolution | keycloak-bootstrap)
+      keycloak-bootstrap)
+        monolog TRACE "Creating 'keycloak-bootstrap-secret'..."
+        kubectl create secret generic keycloak-bootstrap-secret \
+          --from-literal=CLIENT_SECRET=123-456 \
+          --from-literal=keycloak_admin_username=keycloakadmin \
+          --from-literal=keycloak_admin_password=mykeycloakpassword \
+          --from-literal=ATTRIBUTES_USERNAME=user1 \
+          --from-literal=ATTRIBUTES_PASSWORD=testuser123
+        e "create keycloak-bootstrap-secret failed"
+        ;;
+      abacus | entity-resolution)
         # Service without its own secrets
         ;;
       *)

--- a/scripts/lib-local.sh
+++ b/scripts/lib-local.sh
@@ -6,8 +6,10 @@ export PATH="$TOOLS_DIR:$PATH"
 
 e() {
   local rval=$?
-  monolog ERROR "${@}"
-  exit $rval
+  if [[ $rval != 0 ]]; then
+    monolog ERROR "${@}"
+    exit $rval
+  fi
 }
 
 case ${LOCAL_TOOL} in
@@ -20,6 +22,7 @@ case ${LOCAL_TOOL} in
     . "$TOOLS_DIR/lib-minikube.sh"
     ;;
   *)
-    e "Unrecognized local tool [${LOCAL_TOOL}]"
+    monolog ERROR "Unrecognized local tool [${LOCAL_TOOL}]"
+    exit 1
     ;;
 esac

--- a/scripts/pre-reqs-linux.sh
+++ b/scripts/pre-reqs-linux.sh
@@ -14,8 +14,10 @@ export PATH="$BUILD_BIN:$PATH"
 
 e() {
   local rval=$?
-  monolog ERROR "${@}"
-  exit $rval
+  if [[ $rval != 0 ]]; then
+    monolog ERROR "${@}"
+    exit $rval
+  fi
 }
 
 stuff=()
@@ -29,7 +31,8 @@ if [[ $# -gt 0 ]]; then
         stuff+=("$item")
         ;;
       *)
-        e "Unrecognized options: [$item $*]"
+        monolog ERROR "Unrecognized options: [$item $*]"
+        exit 1
         ;;
     esac
   done
@@ -208,7 +211,8 @@ for item in "${stuff[@]}"; do
       i_jq
       ;;
     *)
-      e "Unrecognized option: [$item]"
+      monolog ERROR "Unrecognized options: [$item $*]"
+      exit 1
       ;;
   esac
 done

--- a/scripts/pre-reqs-macos.sh
+++ b/scripts/pre-reqs-macos.sh
@@ -7,8 +7,10 @@ monolog TRACE "pre-reqs-macos: [$0 $*]"
 
 e() {
   local rval=$?
-  monolog ERROR "${@}"
-  exit $rval
+  if [[ $rval != 0 ]]; then
+    monolog ERROR "${@}"
+    exit $rval
+  fi
 }
 
 stuff=()


### PR DESCRIPTION
Various fixes (thanks!)

- Fixes pins to correct Postgres and nginx-ingress images
- Correctly fail with error code in more cases for offline build and test
- Fix misspelling of the entitlements-store chart and entitlements_store image
- Adds some more secret changes over from the quickstart secrets chart to the start.sh which doesn't use it? Why not?


To look up a corresponding image:

```
helm show values --repo https://charts.bitnami.com/bitnami --version 10.16.2 postgresql | yq '.image.tag'
```

This updates the postgresql and docker-registry versions the offline script pulls to match the one in their chart.
