### PR TITLE
PLAT-2046; change destination branch off of main

### DIFF
--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -1,9 +1,7 @@
 on:
   schedule: 
-    # # runs once a week on sunday
-    # - cron: "55 23 * * 0"
-    #testing
-    - cron: "*/2 * * * *"
+    # runs once a week on sunday
+    - cron: "55 23 * * 0"
     
 jobs:
   traffic:
@@ -41,7 +39,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         FILE_TO_COMMIT: data/traffic.csv
-        DESTINATION_BRANCH: ${{ github.ref }} 
+        DESTINATION_BRANCH: analytics
       run: |
         export TODAY=$( date -u '+%Y-%m-%d' )
         export MESSAGE="Weekly Traffic Report Update: regenerate $FILE_TO_COMMIT for $TODAY"

--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -1,7 +1,9 @@
 on:
   schedule: 
-    # runs once a week on sunday
-    - cron: "55 23 * * 0"
+    # # runs once a week on sunday
+    # - cron: "55 23 * * 0"
+    #testing
+    - cron: "*/2 * * * *"
     
 jobs:
   traffic:


### PR DESCRIPTION
changing destination branch to a separate long lives branch called `analytics`. what this will do is commit the generated .csv to `analytics` rather than `main`, meaning no need for the ci status check. The workflow still is triggered from main because schedule trigger only runs on the default branch. 