### PR TITLE
PLAT-2233 try to fix traffic analytics workflow bug

### DIFF
--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -1,12 +1,7 @@
 on:
-  #testing
-  push:
-    branches:
-      - 'PLAT-2233-traffic-bug'
-
-  # schedule: 
-  #   # runs once a week on sunday
-  #   - cron: "55 23 * * 0"
+  schedule: 
+    # runs once a week on sunday
+    - cron: "55 23 * * 0"
     
 jobs:
   traffic:

--- a/.github/workflows/traffic.yaml
+++ b/.github/workflows/traffic.yaml
@@ -1,7 +1,12 @@
 on:
-  schedule: 
-    # runs once a week on sunday
-    - cron: "55 23 * * 0"
+  #testing
+  push:
+    branches:
+      - 'PLAT-2233-traffic-bug'
+
+  # schedule: 
+  #   # runs once a week on sunday
+  #   - cron: "55 23 * * 0"
     
 jobs:
   traffic:
@@ -14,6 +19,8 @@ jobs:
         script: console.log(context)
     - name: checkout repo
       uses: actions/checkout@v3
+      with:
+        ref: analytics
     - name: GitHub traffic  
       uses: actions/github-script@v6
       id: get-traffic


### PR DESCRIPTION
The traffic job is not completing successfully: https://github.com/opentdf/opentdf/actions/runs/3615669931/jobs/6092912990#step:6:21

I believe it is because the workflow isn't checking out the `analytics` branch. It may also be something wrong with how I'm specifying `path` to the write to csv action: https://github.com/opentdf/opentdf/blob/main/.github/workflows/traffic.yaml#L30-L31

But there's no way to test on `main` unless we merge. So I will try this fix first and wait for Sunday to see if it runs successfully. 