### PR TITLE
QuickStart abacus exact path 

### DIFF
--- a/quickstart/helm/values-abacus.yaml
+++ b/quickstart/helm/values-abacus.yaml
@@ -18,6 +18,12 @@ ingress:
       paths: &paths
         - path: /(.*)
           pathType: Prefix
+        - path: /authorities
+          pathType: Exact
+        - path: /attributes
+          pathType: Exact
+        - path: /entitlements
+          pathType: Exact
     - host: host.docker.internal
       paths: *paths
     - host: offline.demo.internal


### PR DESCRIPTION
- Allows OIDC login from endpoints besides root
  -   ex`http://localhost:65432/entitlements`

related to bug https://virtru.atlassian.net/browse/PLAT-2255

[PLAT-2255]: https://virtru.atlassian.net/browse/PLAT-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ