### PR TITLE
🐛 Keycloak and quickstart updates

### DIFF
--- a/examples/Tiltfile
+++ b/examples/Tiltfile
@@ -14,7 +14,7 @@ FRONTEND_CHART_TAG = read_json('../chartsVersions.json')['frontendVersion']
 os.putenv('QUICKSTART_BOOTSTRAP_DISABLED', 'True')
 
 # Where helm values for examples
-os.putenv('HELM_VALUES_PATH', '../examples/helm')
+os.putenv('OPENTDF_HELM_VALUES_PATH', '../examples/helm')
 
 include('../quickstart/Tiltfile')
 

--- a/examples/abacship-app/Tiltfile
+++ b/examples/abacship-app/Tiltfile
@@ -15,7 +15,7 @@ FRONTEND_CHART_TAG = read_json('../../chartsVersions.json')['frontendVersion']
 os.putenv('QUICKSTART_BOOTSTRAP_DISABLED', 'True')
 
 # Where helm values for examples
-os.putenv('HELM_VALUES_PATH', '../examples/helm')
+os.putenv('OPENTDF_HELM_VALUES_PATH', '../examples/helm')
 
 include('../../quickstart/Tiltfile')
 

--- a/examples/secure-remote-storage/Tiltfile
+++ b/examples/secure-remote-storage/Tiltfile
@@ -15,7 +15,7 @@ FRONTEND_CHART_TAG = read_json('../../chartsVersions.json')['frontendVersion']
 os.putenv('QUICKSTART_BOOTSTRAP_DISABLED', 'True')
 
 # Where helm values for examples
-os.putenv('HELM_VALUES_PATH', '../examples/helm')
+os.putenv('OPENTDF_HELM_VALUES_PATH', '../examples/helm')
 
 include('../../quickstart/Tiltfile')
 

--- a/examples/web-app/Tiltfile
+++ b/examples/web-app/Tiltfile
@@ -15,7 +15,7 @@ FRONTEND_CHART_TAG = read_json('../../chartsVersions.json')['frontendVersion']
 os.putenv('QUICKSTART_BOOTSTRAP_DISABLED', 'True')
 
 # Where helm values for examples
-os.putenv('HELM_VALUES_PATH', '../examples/helm')
+os.putenv('OPENTDF_HELM_VALUES_PATH', '../examples/helm')
 
 include('../../quickstart/Tiltfile')
 

--- a/examples/webcam-app/Tiltfile
+++ b/examples/webcam-app/Tiltfile
@@ -15,7 +15,7 @@ FRONTEND_CHART_TAG = read_json('../../chartsVersions.json')['frontendVersion']
 os.putenv('QUICKSTART_BOOTSTRAP_DISABLED', 'True')
 
 # Where helm values for examples
-os.putenv('HELM_VALUES_PATH', '../examples/helm')
+os.putenv('OPENTDF_HELM_VALUES_PATH', '../examples/helm')
 
 # start Quickstart
 # https://docs.tilt.dev/api.html#api.include

--- a/quickstart/Tiltfile
+++ b/quickstart/Tiltfile
@@ -1,7 +1,13 @@
 load("ext://helm_resource", "helm_resource", "helm_repo")
 load("ext://min_tilt_version", "min_tilt_version")
 # load("ext://min_k8s_version", "min_k8s_version")
-load('../version-tool/Tiltfile', 'min_helm_version', "min_kind_version", "min_ctlptl_version", "min_k8s_version")
+load(
+    "../version-tool/Tiltfile",
+    "min_helm_version",
+    "min_kind_version",
+    "min_ctlptl_version",
+    "min_k8s_version",
+)
 
 # The helm_resource extension uses the 'new extensions api' introduced in tilt 0.25
 min_tilt_version("0.25")
@@ -11,17 +17,24 @@ min_kind_version("0.12.0")
 min_ctlptl_version("0.7.4")
 
 
-
-# Where the redirect URI should go to, for example
-EXTERNAL_URL = "http://localhost:65432"
-
 # Versions of things backend to pull (attributes, kas, etc)
 BACKEND_CHART_TAG = read_json('../chartsVersions.json')['backendVersion']
 FRONTEND_CHART_TAG = read_json('../chartsVersions.json')['frontendVersion']
-HELM_VALUES_PATH = "helm/"
+
 # Where helm values for quickstart
-if "HELM_VALUES_PATH" in os.environ:
-    HELM_VALUES_PATH = os.getenv("HELM_VALUES_PATH")
+HELM_VALUES_PATH = os.getenv("OPENTDF_HELM_VALUES_PATH", "helm/")
+
+# Where the redirect URI should go to, for example
+EXTERNAL_URL = os.getenv("OPENTDF_EXTERNAL_URL", "http://localhost:65432")
+
+# Where the redirect URI should go to, for example
+LOAD_FRONTEND = os.getenv("OPENTDF_LOAD_FRONTEND", "1")
+LOAD_FRONTEND = (
+    LOAD_FRONTEND and LOAD_FRONTEND != "0" and LOAD_FRONTEND.lower() != "false"
+)
+
+# Ingress host port
+INGRESS_HOST_PORT = os.getenv("OPENTDF_INGRESS_HOST_PORT", "65432")
 
 k8s_yaml(
     helm(
@@ -57,7 +70,7 @@ helm_resource(
         "controller.admissionWebhooks.enabled=false",
     ],
     labels="third-party",
-    port_forwards="65432:80",
+    port_forwards=("{}:80".format(INGRESS_HOST_PORT) if INGRESS_HOST_PORT else None),
     resource_deps=["k8s-in"],
 )
 
@@ -172,24 +185,25 @@ if not os.environ.get("QUICKSTART_BOOTSTRAP_DISABLED"):
     )
 
 
-helm_resource(
-    "abacus",
-    "oci://ghcr.io/opentdf/charts/abacus",
-    flags=[
-        "--version",
-        FRONTEND_CHART_TAG,
-        "-f",
-        "%s/values-abacus.yaml" % HELM_VALUES_PATH,
-        "--set",
-        "attributes.serverUrl=%s/api/attributes" % EXTERNAL_URL,
-        "--set",
-        "entitlements.serverUrl=%s/api/entitlements" % EXTERNAL_URL,
-        "--set",
-        "oidc.serverUrl=%s/auth/" % EXTERNAL_URL,
-    ],
-    labels="frontend",
-    resource_deps=["keycloak-bootstrap"],
-)
+if LOAD_FRONTEND:
+    helm_resource(
+        "abacus",
+        "oci://ghcr.io/opentdf/charts/abacus",
+        flags=[
+            "--version",
+            FRONTEND_CHART_TAG,
+            "-f",
+            "%s/values-abacus.yaml" % HELM_VALUES_PATH,
+            "--set",
+            "attributes.serverUrl=%s/api/attributes" % EXTERNAL_URL,
+            "--set",
+            "entitlements.serverUrl=%s/api/entitlements" % EXTERNAL_URL,
+            "--set",
+            "oidc.serverUrl=%s/auth/" % EXTERNAL_URL,
+        ],
+        labels="frontend",
+        resource_deps=["keycloak-bootstrap"],
+    )
 
 # ability to pass in custom test script with path to script as env var
 # e.g.: CI=1 TEST_SCRIPT=tests/wait-and-test.sh tilt up

--- a/quickstart/helm/secrets/templates/secrets.yaml
+++ b/quickstart/helm/secrets/templates/secrets.yaml
@@ -83,8 +83,6 @@ type: Opaque
 data:
   KEYCLOAK_ADMIN: {{ "keycloakadmin" | b64enc | quote  }}
   KEYCLOAK_ADMIN_PASSWORD: {{ "mykeycloakpassword" | b64enc | quote }}
-  KC_HOSTNAME: {{ "localhost:65432" | b64enc | quote }}
-  KC_HOSTNAME_ADMIN: {{ "localhost:65432" | b64enc | quote }}
   KC_DB_USERNAME: {{ "postgres" | b64enc | quote }}
   KC_DB_PASSWORD: {{ "myPostgresPassword" | b64enc | quote }}
   KC_DB_URL_HOST: {{ "postgresql" | b64enc | quote }}

--- a/quickstart/helm/values-keycloak.yaml
+++ b/quickstart/helm/values-keycloak.yaml
@@ -2,7 +2,7 @@ fullnameOverride: keycloak
 image:
   # Keycloak is a non-OpenTDF chart, but with an OpenTDF image
   repository: ghcr.io/opentdf/keycloak
-  tag: 19.0.2
+  tag: 19.0.2-1.2.1
 postgresql:
   # This next option (enabled) determines whehter or not Keycloak should 
   # create a Postgres (uniquely) for Keycloak (true) or not (false).
@@ -16,26 +16,32 @@ command:
 externalDatabase:
   database: keycloak_database
 extraEnv: |-
-  - name: KC_LOG_LEVEL
-    value: INFO
   - name: CLAIMS_URL
     value: http://entitlement-pdp:3355/entitlements
+  - name: JAVA_OPTS_APPEND
+    value: -Djgroups.dns.query=keycloak-headless
   - name: KC_DB
     value: postgres
   - name: KC_DB_URL_PORT
     value: "5432"
-  - name: KC_HTTP_RELATIVE_PATH
-    value: "/auth"
-  - name: KC_HOSTNAME_STRICT_HTTPS
-    value: "false"
+  - name: KC_LOG_LEVEL
+    value: INFO
+  - name: KC_HOSTNAME_ADMIN
+    value: "localhost:65432"
   - name: KC_HOSTNAME_STRICT
     value: "false"
+  - name: KC_HOSTNAME_STRICT_BACKCHANNEL
+    value: "false"
+  - name: KC_HOSTNAME_STRICT_HTTPS
+    value: "false"
+  - name: KC_HOSTNAME_URL
+    value: "http://localhost:65432/auth"
   - name: KC_HTTP_ENABLED
     value: "true"
+  - name: KC_HTTP_RELATIVE_PATH
+    value: "/auth"
   - name: KC_PROXY
     value: "edge"
-  - name: JAVA_OPTS_APPEND
-    value: -Djgroups.dns.query=keycloak-headless
 extraEnvFrom: |-
   - secretRef:
       name: "keycloak-secrets"

--- a/quickstart/start.sh
+++ b/quickstart/start.sh
@@ -210,8 +210,6 @@ if [[ $LOAD_SECRETS ]]; then
           kubectl create secret generic keycloak-secrets \
             --from-literal=KEYCLOAK_ADMIN=keycloakadmin \
             --from-literal=KEYCLOAK_ADMIN_PASSWORD=mykeycloakpassword \
-            --from-literal=KC_HOSTNAME=localhost:65432 \
-            --from-literal=KC_HOSTNAME_ADMIN=localhost:65432 \
             --from-literal=KC_DB_USERNAME=postgres \
             --from-literal=KC_DB_PASSWORD=myPostgresPassword \
             --from-literal=KC_DB_URL_HOST=postgresql \


### PR DESCRIPTION
Some small updates for quickstart and related files:

- Updates KC parameters to match current set in backend umbrella chart. This fixes http://localhost:65432/auth/realms/tdf/.well-known/openid-configuration having some urls with the port and some without , among other things.
- Enable custom ingress port forward with the `OPENTDF_INGRESS_HOST_PORT` parameter. This is useful for local development, e.g. running a custom abacus or local demo app in the host OS  which is may be faster than running the dev app in the k8s cluster
- Adds `OPENTDF_LOAD_FRONTEND` boolean parameter to allow disabling abacus. Again, this is most useful while developing abacus itself (or other front end example apps)
- Renames `HELM_VALUES_PATH` `OPENTDF_HELM_VALUES_PATH` to match other env variable config names
