### PR TITLE
🐛 Fix tdf_claims mapper in browsertest client

### DIFF
--- a/quickstart/helm/values-keycloak-bootstrap.yaml
+++ b/quickstart/helm/values-keycloak-bootstrap.yaml
@@ -290,7 +290,7 @@ keycloak:
           id.token.claim: "false"
           userinfo.token.claim: "true"
         name: Access tdf_claims
-        protocolMapper: oidc-audience-mapper
+        protocolMapper: virtru-oidc-protocolmapper
       - protocol: openid-connect
         config:
           claim.name: tdf_claims
@@ -300,7 +300,7 @@ keycloak:
           id.token.claim: "true"
           userinfo.token.claim: "false"
         name: UserInfo tdf_claims
-        protocolMapper: oidc-audience-mapper
+        protocolMapper: virtru-oidc-protocolmapper
 
     users:
 # general test users


### PR DESCRIPTION
I used the wrong mapper type (audience just sets the `aud` parameter, this mapper is the one  that gets tdf_claims and does DPoP processing)